### PR TITLE
Add endpoint for multi-file test generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,9 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, send_file
 from extract_method import extract_method
 from junit_test_generator import generate_junit_test
 import os
+import io
+import zipfile
 
 app = Flask(__name__)
 
@@ -28,6 +30,41 @@ def generate():
 
     junit_test = generate_junit_test(method_code)
     return jsonify({'junit_test': junit_test})
+
+
+@app.route('/generate-tests', methods=['POST'])
+def generate_tests():
+    """Generate tests for multiple Java source files."""
+    data = request.get_json()
+    if not data or 'files' not in data:
+        return jsonify({'error': 'No files provided'}), 400
+
+    files = data['files']
+    if not isinstance(files, list):
+        return jsonify({'error': 'files must be a list'}), 400
+
+    # Map of output filename to test content
+    test_files = {}
+    for file in files:
+        name = file.get('name')
+        content = file.get('content')
+        if not name or content is None:
+            continue
+        junit = generate_junit_test(content)
+        test_name = name.rsplit('.', 1)[0] + 'Test.java'
+        test_files[test_name] = junit
+
+    mem_zip = io.BytesIO()
+    with zipfile.ZipFile(mem_zip, 'w') as zf:
+        for fname, code in test_files.items():
+            zf.writestr(fname, code)
+    mem_zip.seek(0)
+    return send_file(
+        mem_zip,
+        mimetype='application/zip',
+        as_attachment=True,
+        download_name='junit-tests.zip'
+    )
 
 if __name__ == '__main__':
     port = int(os.getenv('PORT', 8000))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,6 +20,23 @@ class TestApp(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json(), {'junit_test': 'junit code'})
 
+    @patch('app.generate_junit_test')
+    def test_generate_tests_endpoint(self, mock_generate):
+        from app import app
+        mock_generate.return_value = 'junit code'
+        payload = {
+            'files': [
+                {'name': 'Example.java', 'content': 'class Example {}'}
+            ]
+        }
+        response = self.client.post('/generate-tests', json=payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers['Content-Type'], 'application/zip')
+        import io, zipfile
+        zf = zipfile.ZipFile(io.BytesIO(response.data))
+        self.assertIn('ExampleTest.java', zf.namelist())
+        self.assertEqual(zf.read('ExampleTest.java').decode(), 'junit code')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- provide a new API route `/generate-tests` that accepts multiple Java files and returns a ZIP of generated tests
- support zipped responses from the backend to integrate with the Streamlit frontend
- test new endpoint in `tests/test_app.py`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e43148f8083228571ecab61cd8aac