### PR TITLE
Add optional LangChain and LangSmith support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Install Python dependencies:
 pip install -r requirements.txt
 ```
 
+The backend optionally integrates with **LangChain** and **LangSmith** for LLM
+invocation and tracing. If these packages are unavailable, the server falls
+back to using the raw OpenAI client.
+
 A Java runtime is required for the `ExtractMethod` class. Make sure the
 `javaparser-core-3.25.4.jar` is present in the repository.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 flask
 openai
 langgraph
+langchain
+langsmith


### PR DESCRIPTION
## Summary
- extend requirements with `langchain` and `langsmith`
- integrate optional LangChain `ChatOpenAI` and LangSmith tracing in `junit_test_generator.py`
- mention LangChain/LangSmith in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e46768ca083228be61b604f9eb377